### PR TITLE
Potential fix for code scanning alert no. 2: Missing rate limiting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
         "cors": "^2.8.5",
         "dotenv": "^17.2.2",
         "express": "^5.1.0",
+        "express-rate-limit": "^8.2.1",
+        "ip-address": "^10.0.1",
         "lucide-react": "^0.544.0",
         "nodemailer": "^7.0.7",
         "react": "^19.1.1",
@@ -2474,6 +2476,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
+      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.0.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2952,6 +2972,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "nodemailer": "^7.0.7",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-    "react-icons": "^5.5.0"
+    "react-icons": "^5.5.0",
+    "express-rate-limit": "^8.2.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/package.json
+++ b/package.json
@@ -14,12 +14,13 @@
     "cors": "^2.8.5",
     "dotenv": "^17.2.2",
     "express": "^5.1.0",
+    "express-rate-limit": "^8.2.1",
+    "ip-address": "^10.0.1",
     "lucide-react": "^0.544.0",
     "nodemailer": "^7.0.7",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-    "react-icons": "^5.5.0",
-    "express-rate-limit": "^8.2.1"
+    "react-icons": "^5.5.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/server.js
+++ b/server.js
@@ -57,8 +57,9 @@ app.post("/api/send-email", async (req, res) => {
 app.use(express.static(path.join(__dirname, "./dist")));
 
 // ✅ Catch-all: frontend routes go to React
+// Included a catch limiter
 const catchAllLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000, // 15 minutes
+  windowMs: 15 * 60 * 1000, // 15 minutes - how long a request should be remembered
   max: 100, // limit each IP to 100 requests per windowMs
 });
 app.get(/.*/, catchAllLimiter, (req, res) => {

--- a/server.js
+++ b/server.js
@@ -4,6 +4,7 @@ import cors from "cors";
 import dotenv from "dotenv";
 import path from "path";
 import { fileURLToPath } from "url";
+import rateLimit from "express-rate-limit";
 
 dotenv.config();
 
@@ -56,7 +57,11 @@ app.post("/api/send-email", async (req, res) => {
 app.use(express.static(path.join(__dirname, "./dist")));
 
 // ✅ Catch-all: frontend routes go to React
-app.get(/.*/, (req, res) => {
+const catchAllLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+});
+app.get(/.*/, catchAllLimiter, (req, res) => {
   res.sendFile(path.join(__dirname, "./dist", "index.html"));
 });
 


### PR DESCRIPTION
Potential fix for [https://github.com/hamtana/ReviewEngine/security/code-scanning/2](https://github.com/hamtana/ReviewEngine/security/code-scanning/2)

The best fix for this problem is to apply rate limiting middleware to the catch-all route that serves `index.html`. This will limit the number of requests per IP in a given time window, reducing risk of denial-of-service attacks through repeated file system accesses. The recommended approach is to use a well-known rate-limiting library, such as `express-rate-limit`. You should import this package near the top of the file, create a limiter instance with reasonable defaults (e.g., 100 requests per 15 minutes per IP), and apply it specifically to the catch-all route (not globally, as other routes like static file serving and APIs may have different requirements). This involves inserting the limiter middleware in the `app.get(/.*/, ...)` route.

Steps:
1. Add `express-rate-limit` import near the top.
2. Instantiate a rate limiter (e.g., under main route or above catch-all).
3. Apply the rate limiter to the catch-all route by passing it as middleware.
4. No change to response or route handler logic.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
