### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/hamtana/ReviewEngine/security/code-scanning/1](https://github.com/hamtana/ReviewEngine/security/code-scanning/1)

In general, the fix is to explicitly declare a `permissions` block in the workflow, either at the root level (to apply to all jobs) or within the `build` job. Since this workflow only checks out code and runs build commands, it only needs read access to repository contents, so we can set `contents: read` as the minimal permission.

The best fix without changing functionality is to add a top-level `permissions` section after the `on:` block. This will apply to the `build` job and any future jobs that do not override permissions, ensuring the `GITHUB_TOKEN` is restricted to read-only access to repository contents. No other changes to steps or actions are needed.

Concretely, in `.github/workflows/node.js.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on:` block (lines 6–10) and the `jobs:` block (line 12). No imports or additional definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
